### PR TITLE
[Fix] match spec

### DIFF
--- a/.changeset/tidy-walls-check.md
+++ b/.changeset/tidy-walls-check.md
@@ -1,0 +1,5 @@
+---
+"@bigandy/sibling-count": major
+---
+
+match spec with regards sibling-count being on children not parent.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A web component that allows you to put --sibling-count on the parent item, as we
 
 ## Notes
 
-You can import with unpkg `https://unpkg.com/@bigandy/sibling-count@1.3.1` and then use in your HTML
+You can import with unpkg `https://unpkg.com/@bigandy/sibling-count@2.0.0` and then use in your HTML
 
 <details open>
 <summary>input html</summary>
@@ -47,22 +47,22 @@ You can import with unpkg `https://unpkg.com/@bigandy/sibling-count@1.3.1` and t
 
 </details>
 
-<details>
+<details open>
 <summary>output html</summary>
 which will yield the following HTML when the web-component JS is run:
 
 ```html
-<ul style="--sibling-count: 10;">
-  <li style="--sibling-index: 1;"></li>
-  <li style="--sibling-index: 2;"></li>
-  <li style="--sibling-index: 3;"></li>
-  <li style="--sibling-index: 4;"></li>
-  <li style="--sibling-index: 5;"></li>
-  <li style="--sibling-index: 6;"></li>
-  <li style="--sibling-index: 7;"></li>
-  <li style="--sibling-index: 8;"></li>
-  <li style="--sibling-index: 9;"></li>
-  <li style="--sibling-index: 10;"></li>
+<ul>
+  <li style="--sibling-index: 1; --sibling-count: 10;"></li>
+  <li style="--sibling-index: 2; --sibling-count: 10;"></li>
+  <li style="--sibling-index: 3; --sibling-count: 10;"></li>
+  <li style="--sibling-index: 4; --sibling-count: 10;"></li>
+  <li style="--sibling-index: 5; --sibling-count: 10;"></li>
+  <li style="--sibling-index: 6; --sibling-count: 10;"></li>
+  <li style="--sibling-index: 7; --sibling-count: 10;"></li>
+  <li style="--sibling-index: 8; --sibling-count: 10;"></li>
+  <li style="--sibling-index: 9; --sibling-count: 10;"></li>
+  <li style="--sibling-index: 10; --sibling-count: 10;"></li>
 </ul>
 ```
 

--- a/src/__snapshots__/sibling-count.test.ts.snap
+++ b/src/__snapshots__/sibling-count.test.ts.snap
@@ -2,23 +2,21 @@
 
 exports[`SiblingCount > should match the snapshot 1`] = `
 <sibling-count>
-  <ul
-    style="--sibling-count: 3;"
-  >
+  <ul>
     
                 
     <li
-      style="--sibling-index: 1;"
+      style="--sibling-index: 1; --sibling-count: 3;"
     />
     
                 
     <li
-      style="--sibling-index: 2;"
+      style="--sibling-index: 2; --sibling-count: 3;"
     />
     
                 
     <li
-      style="--sibling-index: 3;"
+      style="--sibling-index: 3; --sibling-count: 3;"
     />
     
               

--- a/src/sibling-count.test.ts
+++ b/src/sibling-count.test.ts
@@ -32,17 +32,18 @@ describe("SiblingCount", () => {
     expect(siblingCount).toBeDefined();
   });
 
-  it("the parent should have a --sibling-count matching the number of children", () => {
-    const siblingCount = createSiblingCount();
+  /* This test is wrong. The spec says that each item should have a sibling-count() not the parent. */
+  //   it("the parent should have a --sibling-count matching the number of children", () => {
+  //     const siblingCount = createSiblingCount();
 
-    const list = siblingCount.querySelector("ul")!;
-    const listItems = list.querySelectorAll("li");
-    const siblingCountValue =
-      getComputedStyle(list).getPropertyValue("--sibling-count");
+  //     const list = siblingCount.querySelector("ul")!;
+  //     const listItems = list.querySelectorAll("li");
+  //     const siblingCountValue =
+  //       getComputedStyle(list).getPropertyValue("--sibling-count");
 
-    expect(siblingCountValue).toBe("3");
-    expect(listItems.length).toBe(3);
-  });
+  //     expect(siblingCountValue).toBe("3");
+  //     expect(listItems.length).toBe(3);
+  //   });
 
   it("for each of the children: should have a --sibling-index matching the 1-based index", () => {
     const siblingCount = createSiblingCount();
@@ -50,13 +51,27 @@ describe("SiblingCount", () => {
     const list = siblingCount.querySelector("ul")!;
     const listItems = list.querySelectorAll("li");
 
-    // Loop through list items, check their
+    // Loop through list items, check their --sibling-index matches the index
     let index = 1;
     for (const listItem of listItems) {
       const siblingIndexValue =
         getComputedStyle(listItem).getPropertyValue("--sibling-index");
       expect(siblingIndexValue).toBe(String(index));
       index++;
+    }
+  });
+
+  it("for each of the children: should have a --sibling-count matching the number of siblings that the element has", () => {
+    const siblingCount = createSiblingCount();
+
+    const list = siblingCount.querySelector("ul")!;
+    const listItems = list.querySelectorAll("li");
+
+    for (const listItem of listItems) {
+      const siblingIndexValue =
+        getComputedStyle(listItem).getPropertyValue("--sibling-count");
+
+      expect(siblingIndexValue).toBe(String(listItems.length));
     }
   });
 

--- a/src/sibling-count.ts
+++ b/src/sibling-count.ts
@@ -75,8 +75,6 @@ class SiblingCount extends HTMLElement {
       return;
     }
 
-    this.setAttributeOrStyle(parent, "sibling-count", String(siblingCount));
-
     const siblings = [...parent.children];
     // Loop through all the children and add the custom property sibling-index to each.
 
@@ -86,6 +84,12 @@ class SiblingCount extends HTMLElement {
         sibling as HTMLElement,
         "sibling-index",
         siblingIndex,
+      );
+
+      this.setAttributeOrStyle(
+        sibling as HTMLElement,
+        "sibling-count",
+        String(siblingCount),
       );
     });
   }


### PR DESCRIPTION
Re-reading the spec and the sibling-count() should be on the children not the parent. 