### PR TITLE
feat: handle browsers that already support sibling-child() selector.

### DIFF
--- a/.changeset/nice-oranges-cut.md
+++ b/.changeset/nice-oranges-cut.md
@@ -1,0 +1,5 @@
+---
+"@bigandy/sibling-count": major
+---
+
+handle browsers that support this feature

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Sibling-count Web Component
 
-A web component that allows you to put --sibling-count on the parent item, as well as --sibling-index on each child item. This allows cool things such as https://nerdy.dev/cyclical-radio-group-with-trig-functions-and-grid but without the hard-work of hand-coding the css variables. Here's the [CSSWG ticket](https://github.com/w3c/csswg-drafts/issues/4559).
+A web component that allows you to prototype the sibling-count() and sibling-index() functions that are part of the [CSS-Values-5 spec](https://www.w3.org/TR/css-values-5/#tree-counting). This allows cool things such as https://nerdy.dev/cyclical-radio-group-with-trig-functions-and-grid but without the hard-work of hand-coding the css variables. Here's the [CSSWG ticket](https://github.com/w3c/csswg-drafts/issues/4559).
+
+As of March 2025 this feature is being [prototyped in Chrome Canary](https://issues.chromium.org/issues/40282719) under the "Experimental Web Platform features" flag.
 
 ## Scripts
 
@@ -8,8 +10,8 @@ A web component that allows you to put --sibling-count on the parent item, as we
 - `npm run build` - builds the project with vite build
 - `npm run local-release` - publishes the package to npm (needs One Time Password) after doing all the checks beforehand
 - `npx changeset` - creates a changeset of the latest changes. You can choose if it is a patch, minor, or major change.
-- `npm run test` - runs the tests with vitest
-- `npm run test:watch` runs the tests in watch mode
+- `npm run test` - runs the tests with vitest in watch mode
+- `npm run check-test` runs the tests
 
 ## To create a new release
 
@@ -97,28 +99,7 @@ ul {
 Resulting in this:<br />
 <img width="511" alt="Screenshot 2023-08-29 at 16 47 38" src="https://github.com/bigandy/sibling-count/assets/603328/0313dd70-d5c6-4db6-a01a-7892913adc1b">
 
-## Do not
-
-If you provide more than one one top-level child, you'll get a console.warn message telling you not to. For example
-
-```html
-<sibling-count>
-  <ul>
-    <li></li>
-    <li></li>
-    <li></li>
-    <li></li>
-    <li></li>
-  </ul>
-  <ul>
-    <li></li>
-    <li></li>
-    <li></li>
-    <li></li>
-    <li></li>
-  </ul>
-</sibling-count>
-```
+## Do Not
 
 If you pass a top-level element with no children, you'll also get a console.warn message. For example:
 
@@ -128,15 +109,15 @@ If you pass a top-level element with no children, you'll also get a console.warn
 </sibling-count>
 ```
 
-## Optional Props
+## Optional attributes
 
 ### keepTrackOfUpdates
 
-Should you want the custom element to keep track of updates to the number of children you can use the `keepTrackOfUpdates` attribute.
+Should you want the custom element to keep track of updates to the number of children you can use the `keep-track-of-updates` attribute.
 
-### initialIndex
+### futureFriendly
 
-Should you want the count to start at a number that is not 1 then you can use the `initialIndex` attribute
+Chrome Canary are prototyping this feature under a flag. If you want the web component to check if your browser supports this feature (falling back to inline style if the browser does not) then use the `future-friendly` attribute.
 
 ## Misc Notes
 

--- a/index.html
+++ b/index.html
@@ -17,13 +17,16 @@
         height: 20px;
         aspect-ratio: 1;
         border-radius: 50%;
-        background: hsl(calc(var(--sibling-index) * 300deg) 100% 50%);
+
+        --_hue: calc(var(--sibling-index, sibling-index()) * 300deg);
+
+        background: hsl(var(--_hue) 100% 50%);
       }
     </style>
   </head>
   <body>
     <p>Test with blank spaces removed</p>
-    <sibling-count
+    <sibling-count future-friendly
       ><ul>
         <li></li>
         <li></li>
@@ -34,7 +37,7 @@
         <li></li></ul
     ></sibling-count>
     <p>Test with blank spaces</p>
-    <sibling-count>
+    <sibling-count future-friendly>
       <ul>
         <li></li>
         <li></li>
@@ -46,28 +49,18 @@
       </ul>
     </sibling-count>
 
-    <p>Using starting-index</p>
-    <sibling-count initial-index="3">
-      <ul>
-        <li></li>
-        <li></li>
-        <li></li>
-        <li></li>
-        <li></li>
-        <li></li>
-        <li></li>
-      </ul>
-    </sibling-count>
-
-    <p>Test with a paragraph</p>
-    <sibling-count>
+    <p>
+      Test with a paragraph that contains no children. Should show a
+      console.warn message
+    </p>
+    <sibling-count future-friendly>
       <p>This is cool?</p>
     </sibling-count>
 
     <p>Example with two top-level children that contain children</p>
 
     <p>Test with a paragraph</p>
-    <sibling-count>
+    <sibling-count future-friendly>
       <ul>
         <li></li>
         <li></li>

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@bigandy/sibling-count",
   "version": "2.0.0",
   "author": "Andrew JD Hudson @bigandy (https://andrewhudson.dev/)",
-  "description": "A web component that shows the count the number of siblings of a parent element and the index of each child element.",
+  "description": "A web component that allows you to prototype the sibling-count() and sibling-index() functions that are part of the CSS-Values-5 spec",
   "keywords": [
     "sibling-count",
     "sibling-index",
@@ -18,16 +18,16 @@
     "dev": "vite",
     "build": "tsup",
     "npm:publish": "npm publish --access=public",
-    "lint": "tsc",
-    "ci": "npm run build && npm run check-format && npm run check-exports && npm run lint && npm run test",
+    "check-lint": "tsc",
+    "ci": "npm run build && npm run check-format && npm run check-exports && npm run check-lint && npm run check-test",
     "format": "prettier --write .",
     "check-format": "prettier --check .",
     "check-exports": "attw --pack . --ignore-rules=cjs-resolves-to-esm",
     "local-release": "changeset version && changeset publish",
     "release": "npm run ci && changeset publish",
     "prepublishOnly": "npm run ci",
-    "test": "vitest run",
-    "test:watch": "vitest"
+    "test": "vitest",
+    "check-test": "vitest run"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.17.4",

--- a/src/__snapshots__/sibling-count.test.ts.snap
+++ b/src/__snapshots__/sibling-count.test.ts.snap
@@ -1,5 +1,56 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`SiblingCount > should handle the situation where there are more than one top-level children of <sibling-count> 1`] = `
+<sibling-count>
+  
+      
+  <ul>
+    <li
+      style="--sibling-index: 1; --sibling-count: 6;"
+    />
+    <li
+      style="--sibling-index: 2; --sibling-count: 6;"
+    />
+    <li
+      style="--sibling-index: 3; --sibling-count: 6;"
+    />
+    <li
+      style="--sibling-index: 4; --sibling-count: 6;"
+    />
+    <li
+      style="--sibling-index: 5; --sibling-count: 6;"
+    />
+    <li
+      style="--sibling-index: 6; --sibling-count: 6;"
+    />
+  </ul>
+  
+      
+  <ul>
+    <li
+      style="--sibling-index: 1; --sibling-count: 6;"
+    />
+    <li
+      style="--sibling-index: 2; --sibling-count: 6;"
+    />
+    <li
+      style="--sibling-index: 3; --sibling-count: 6;"
+    />
+    <li
+      style="--sibling-index: 4; --sibling-count: 6;"
+    />
+    <li
+      style="--sibling-index: 5; --sibling-count: 6;"
+    />
+    <li
+      style="--sibling-index: 6; --sibling-count: 6;"
+    />
+  </ul>
+  
+      
+</sibling-count>
+`;
+
 exports[`SiblingCount > should match the snapshot 1`] = `
 <sibling-count>
   <ul>

--- a/src/sibling-count.test.ts
+++ b/src/sibling-count.test.ts
@@ -87,16 +87,34 @@ describe("SiblingCount", () => {
   });
 
   it("should handle the situation where there are more than one top-level children of <sibling-count>", () => {
-    createSiblingCount(
+    const siblingCount = createSiblingCount(
       `
-      <ul><li></li></ul><ul><li></li></ul>
-      <ul><li></li></ul><ul><li></li></ul>
+      <ul><li></li><li></li><li></li><li></li><li></li><li></li></ul>
+      <ul><li></li><li></li><li></li><li></li><li></li><li></li></ul>
       `,
     );
 
-    expect(consoleMock).toHaveBeenCalledOnce();
-    expect(consoleMock).toHaveBeenLastCalledWith(
-      "Sibling Count - Only one parent element is allowed.",
-    );
+    const lists = siblingCount.querySelectorAll("ul");
+
+    for (const list of lists) {
+      const listItems = list.querySelectorAll("li");
+
+      for (const listItem of listItems) {
+        const siblingIndexValue =
+          getComputedStyle(listItem).getPropertyValue("--sibling-count");
+
+        expect(siblingIndexValue).toBe(String(listItems.length));
+
+        let index = 1;
+        for (const listItem of listItems) {
+          const siblingIndexValue =
+            getComputedStyle(listItem).getPropertyValue("--sibling-index");
+          expect(siblingIndexValue).toBe(String(index));
+          index++;
+        }
+      }
+    }
+
+    expect(siblingCount).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
Now that Chrome Canary are protoyping (behind a feature flag), I have added an attribute to check if the browser supports the feature and if it does to use it rather than the inline styles approach.

In your CSS it is easy to cover both cases:

```css
margin-left: calc(var(--sibling-child, sibling-child()) * 10px);
```

Resolves #15 